### PR TITLE
Added UXD Hub quick starts content guidelines to quick-starts.md

### DIFF
--- a/conventions/documentation/quick-starts.md
+++ b/conventions/documentation/quick-starts.md
@@ -37,6 +37,8 @@ See [documentation](https://docs.openshift.com/container-platform/4.7/web_consol
 ## How do I write a quick start?
 See [documentation](https://docs.openshift.com/container-platform/4.7/web_console/creating-quick-start-tutorials.html).
 
+Also see _Best practices for writing quick starts_ on [UXD Hub](https://www.uxd-hub.com/entries/resource/best-practices-for-writing-quick-starts) for content guidelines.
+
 ## How do I contribute a quick start?
 
 This section goes over the following:


### PR DESCRIPTION
Added link to the UXD Hub quick starts style/content guidelines, created by Red Hat UXD & docs teams.

The aim of the UXD Hub resource is to combine the guidance from all the various guidelines & best practices for writing PatternFly quick starts to help teams create more consistent quick starts by following a single source of truth. See https://issues.redhat.com/browse/HCCDOC-2517 for more info on this initiative.

The OpenShift quick starts doc was one of the sources pulled from to create the more general UXD Hub resource. 

Thank you for reviewing and merging!

<!-- Write a sentence or two below describing what this PR includes along with any additional information that could be helpful to reviewers. -->

Description here.

<!-- The top of each Markdown file should include a Parent (Administrator, Developer, etc.) and Version (4.0, 4.x, etc.). When possible, name Markdown files index.md for cleaner URLs.  -->

<!-- Required team mentions: -->
@openshift/team-ux-leads

<!-- Optional team mentions (include any that are related to this PR): -->
@openshift/team-ux-review (Administrator perspective)
@openshift/team-devconsole-ux (Developer perspective)
@openshift/team-kni-ux (KNI & Virtualization)